### PR TITLE
Migrates remaining markdown files

### DIFF
--- a/site_content/_pages/contributing_code/code.md
+++ b/site_content/_pages/contributing_code/code.md
@@ -25,12 +25,6 @@ Many developers in the Samvera community practice [test-driven development](http
 
 We tend to use RSpec as our testing tool of choice, with Capybara for feature tests, and our tests tend to conform to [community-driven testing guidelines](http://betterspecs.org/). All of our codebases on GitHub integrate with the Travis continuous integration service, which allows reviewers to see if changes made in pull requests have a passing test suite. We also tend to use Coveralls to determine whether the proposed changes have increased or decreased overall code coverage.
 
-## Style guidelines
-
-The Samvera community uses a somewhat modified version of the default Ruby style conventions provided by the Rubocop tool. If your pull request contains style violations, continuous integration builds will fail quickly and your work will be in an unmergeable state.
-
-Fortunately, it's very easy (and fast) to check this in your development environment. Run the `rubocop` command to see if your changes pass muster. If they do not, Rubocop also supports an auto-fix flag for some violations. To do this, run `rubocop -a` -- but we recommend committing your changes first, because though this seldom happens, Rubocop can sometimes "fix" your code into a state that causes tests to fail. (Don't worry about having to commit earlier, or more, than you intended; you can always squash your commits later.)
-
 ## Pull request size and shape
 
 We have found over the years that it is best when pull requests are small; targeted at a specific issue; and pushed up quickly for review.

--- a/site_content/_software/hyrax/v1.0/developer/access-controls.md
+++ b/site_content/_software/hyrax/v1.0/developer/access-controls.md
@@ -1,0 +1,62 @@
+---
+title: "Visibility and Access Controls"
+permalink: access-controls.html
+keywords: ["Visibility", "Access Controls", "Authorization"]
+last_updated:
+tags: [development_resources]
+summary: 'An overview of how Samvera applications authorize users to see content and perform actions'
+sidebar: home_sidebar
+---
+### Quickstart
+Samvera uses [cancancan](https://github.com/CanCanCommunity/cancancan#1-define-abilities) to do authorization of many actions.
+
+Cancancan generates `app/models/ability.rb` into your application and then hydra-head's generator and later Hyrax's generator each adds a couple of lines so that the class looks like this:
+
+```
+class Ability
+  include Hydra::Ability
+
+  include Hyrax::Ability
+  self.ability_logic += [:everyone_can_create_curation_concerns]
+
+  # Define any customized permissions here.
+  def custom_permissions
+    # Limits deleting objects to a the admin user
+    #
+    # if current_user.admin?
+    #   can [:destroy], ActiveFedora::Base
+    # end
+
+    # Limits creating new objects to a specific group
+    #
+    # if user_groups.include? 'special_group'
+    #   can [:create], ActiveFedora::Base
+    # end
+  end
+end
+```
+
+You don't need to make any changes to this class as the included behavior provides all that you need to get started.   However, if you are integrating an group system other than the default (See Hydra::RoleMapper), then you may want to change who has the admin role.
+
+You can do this by overriding the `admin?` method on the `Ability` class like this:
+
+```
+    def admin?
+      user_groups.include? 'librarians'
+    end
+```
+### Legacy
+
+In-depth tutorials and explanations of the structure
+
+- [Access Controls with Hydra 9](https://github.com/samvera/hydra-head/wiki/Access-Controls-with-Hydra)
+
+- [Access Controls with Hydra < 9](https://github.com/samvera/hydra-head/wiki/Access-Controls)
+
+### Potential for Refactoring
+
+Notes, links and ideas
+
+- [Oligarchical SaaS with CanCan](https://schwad.github.io/ruby/cancan/saas/2017/04/06/oligarchical-saas-with-cancan.html)
+
+- [Refacotoring Notes: Access Control Details, WIP](https://docs.google.com/document/d/1tWpV8b11WZ5qXP0ZHgFtatVuRg3YFUoMA7jPzU-QB34/edit?usp=sharing)

--- a/site_content/_software/hyrax/v1.0/developer/toggle-features.md
+++ b/site_content/_software/hyrax/v1.0/developer/toggle-features.md
@@ -1,0 +1,25 @@
+---
+title: "How to Enable and Disable Features"
+permalink: toggle-features.html
+keywords: [ "Configuration", "FlipFlop", "Feature Flipper" ]
+last_updated:
+tags: [development_resources]
+summary: 'A number of Hyrax features can be flipped on and off, either via the Administrative Dashboard or via a YAML configuration file'
+sidebar: home_sidebar
+toc: false
+---
+
+Some features in Hyrax can be flipped on and off from either the Administrative Dashboard, or via a YAML configuration file at `config/features.yml`. This .yml file doesn't ship with Hyrax but can easily be created.
+
+``` ruby
+assign_admin_set:
+  enabled: false
+proxy_deposit:
+  enabled: false
+```
+
+For a list of flipper features that can be configured in this way, see the [https://github.com/samvera/hyrax/blob/master/config/features.rb](https://github.com/samvera/hyrax/blob/master/config/features.rb) which defines keys and whether they are enabled by default.
+
+<ul class='warning'><li>If both options exist, whichever option is set from the Administrative Dashboard will take precedence.</li></ul>
+
+For a complete list of features and instructions on how to configure them, see the [Hyrax Feature-matrix](https://github.com/samvera/hyrax/wiki/Feature-matrix).

--- a/site_content/_software/hyrax/v1.0/devops/campus-auth-integrating.md
+++ b/site_content/_software/hyrax/v1.0/devops/campus-auth-integrating.md
@@ -1,0 +1,15 @@
+---
+title: "Integrating with Campus Authorization"
+permalink: campus-auth-integrating.html
+keywords: ["Integration", "Shibboleth", "Authorization"]
+tags: production
+summary: "An example of integrating with Shibboleth"
+toc: false
+---
+
+
+### Authenticate against Shibboleth
+
+There are probably many ways of doing this.
+
+Data Curation Experts has a repeatable way for accomplishing it, documented  [here](https://curationexperts.github.io/playbook/authentication/shibboleth.html).

--- a/site_content/_software/hyrax/v1.0/devops/service-stack.md
+++ b/site_content/_software/hyrax/v1.0/devops/service-stack.md
@@ -1,0 +1,19 @@
+---
+title: "The Services Stack"
+permalink: service-stack.html
+keywords: ["Solr", "Fedora", "Redis", "Services"]
+tags: production
+summary: "Services used in a production setting"
+---
+
+## Solr
+Solr is a search engine.  Samvera creates an index document (basically a Hash) for each PCDM object in Fedora and puts it into Solr.  This allows objects to be searched and discovered by a user.  ActiveFedora also uses Solr to run queries such as "Get me a list of objects that are Images"
+
+## Fedora Commons Repository (a.k.a. Fedora, a.k.a. FCRepo)
+Fedora is a data store that uses the LDP protocol to store linked data and binary files.
+
+## Rails
+Rails is a web application Framework for Ruby.
+
+## Redis
+Redis is a key-value store that we use to back our worker queues (using Resque or Sidekiq). Hyrax also uses Redis for user notifications.

--- a/site_content/_software/hyrax/v1.0/devops/troubleshooting-production.md
+++ b/site_content/_software/hyrax/v1.0/devops/troubleshooting-production.md
@@ -1,0 +1,71 @@
+---
+title: "Troubleshooting Production"
+permalink: troubleshooting-production.html
+keywords: ["Debugging", "Troubleshooting", "Production"]
+last_updated:
+tags: production
+summary: "Known issues regarding running in production"
+sidebar: home_sidebar
+---
+
+# Known gotchas
+
+## displaying default admin set raises exception
+Hyrax creates a default admin set that has a slash in its id ("admin_set/default").
+This means that unless your webserver is configured to allow encoded slashes,
+features that refer to the default admin set in the url will raise an exception.
+If you are using passenger on Ubuntu, you can fix this by adding this line to
+`/etc/apache2/conf-enabled/passenger.conf`:
+```
+  PassengerAllowEncodedSlashes on
+```
+The actual syntax might vary depending on your webserver configuration.
+
+## 'Failed to upgrade to WebSocket' ERROR for Hyrax notifications
+
+It's a known issue that Hyrax notifications don't work with Apache and Passenger.
+
+An alternative approach is to use puma and have Apache reverse proxy to the puma port. In this configuration, you may find that notifications still don't work, with `ERROR: Failed to upgrade to WebSocket` repeatedly appearing in the logs.
+
+The following configuration example has been successfully used as a fix for this issue in Centos7. Note, you will need mod_proxy and mod_proxy_wstunnel enabled.
+
+Please note that this configuration MAY also work with Passenger, but has not been tested.
+
+```
+<VirtualHost *:80>
+  ServerName localhost
+  DocumentRoot /var/lib/hyku/public
+  ProxyPreserveHost On
+
+  # Needed for RIIIF image server
+  AllowEncodedSlashes NoDecode
+
+  <Directory /var/lib/hyku/public>
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+  </Directory>
+
+  # Hyrax notifications require the following re-write configuration
+  #   otherwise notifications won't work and the log will contain lots of:
+  #   "ERROR: Failed to upgrade to WebSocket"
+  # Enable the rewrite engine
+  # Requires: sudo a2enmod proxy rewrite proxy_http proxy_wstunnel
+  # In the rules/conds, [NC] means case-insensitve, [P] means proxy
+  # See https://stackoverflow.com/questions/27526281/websockets-and-apache-proxy-how-to-configure-mod-proxy-wstunnel
+  RewriteEngine On
+
+  # socket.io 1.0+ starts all connections with a HTTP polling request
+  RewriteCond %{QUERY_STRING} notifications/endpoint       [NC]
+  RewriteRule /(.*)           http://localhost:3000/$1 [P]
+
+  # When socket.io wants to initiate a WebSocket connection, it sends an
+  # "upgrade: websocket" request that should be transferred to ws://
+  RewriteCond %{HTTP:Upgrade} websocket               [NC]
+  RewriteRule /(.*)           ws://localhost:3000/$1  [P]
+
+  ProxyPass / http://127.0.0.1:3000/
+  ProxyPassReverse / http://127.0.0.1:3000/
+</VirtualHost>
+
+```

--- a/site_content/_software/hyrax/v2.0/developer/access-controls.md
+++ b/site_content/_software/hyrax/v2.0/developer/access-controls.md
@@ -1,0 +1,62 @@
+---
+title: "Visibility and Access Controls"
+permalink: access-controls.html
+keywords: ["Visibility", "Access Controls", "Authorization"]
+last_updated:
+tags: [development_resources]
+summary: 'An overview of how Samvera applications authorize users to see content and perform actions'
+sidebar: home_sidebar
+---
+### Quickstart
+Samvera uses [cancancan](https://github.com/CanCanCommunity/cancancan#1-define-abilities) to do authorization of many actions.
+
+Cancancan generates `app/models/ability.rb` into your application and then hydra-head's generator and later Hyrax's generator each adds a couple of lines so that the class looks like this:
+
+```
+class Ability
+  include Hydra::Ability
+
+  include Hyrax::Ability
+  self.ability_logic += [:everyone_can_create_curation_concerns]
+
+  # Define any customized permissions here.
+  def custom_permissions
+    # Limits deleting objects to a the admin user
+    #
+    # if current_user.admin?
+    #   can [:destroy], ActiveFedora::Base
+    # end
+
+    # Limits creating new objects to a specific group
+    #
+    # if user_groups.include? 'special_group'
+    #   can [:create], ActiveFedora::Base
+    # end
+  end
+end
+```
+
+You don't need to make any changes to this class as the included behavior provides all that you need to get started.   However, if you are integrating an group system other than the default (See Hydra::RoleMapper), then you may want to change who has the admin role.
+
+You can do this by overriding the `admin?` method on the `Ability` class like this:
+
+```
+    def admin?
+      user_groups.include? 'librarians'
+    end
+```
+### Legacy
+
+In-depth tutorials and explanations of the structure
+
+- [Access Controls with Hydra 9](https://github.com/samvera/hydra-head/wiki/Access-Controls-with-Hydra)
+
+- [Access Controls with Hydra < 9](https://github.com/samvera/hydra-head/wiki/Access-Controls)
+
+### Potential for Refactoring
+
+Notes, links and ideas
+
+- [Oligarchical SaaS with CanCan](https://schwad.github.io/ruby/cancan/saas/2017/04/06/oligarchical-saas-with-cancan.html)
+
+- [Refacotoring Notes: Access Control Details, WIP](https://docs.google.com/document/d/1tWpV8b11WZ5qXP0ZHgFtatVuRg3YFUoMA7jPzU-QB34/edit?usp=sharing)

--- a/site_content/_software/hyrax/v2.0/developer/toggle-features.md
+++ b/site_content/_software/hyrax/v2.0/developer/toggle-features.md
@@ -1,0 +1,25 @@
+---
+title: "How to Enable and Disable Features"
+permalink: toggle-features.html
+keywords: [ "Configuration", "FlipFlop", "Feature Flipper" ]
+last_updated:
+tags: [development_resources]
+summary: 'A number of Hyrax features can be flipped on and off, either via the Administrative Dashboard or via a YAML configuration file'
+sidebar: home_sidebar
+toc: false
+---
+
+Some features in Hyrax can be flipped on and off from either the Administrative Dashboard, or via a YAML configuration file at `config/features.yml`. This .yml file doesn't ship with Hyrax but can easily be created.
+
+``` ruby
+assign_admin_set:
+  enabled: false
+proxy_deposit:
+  enabled: false
+```
+
+For a list of flipper features that can be configured in this way, see the [https://github.com/samvera/hyrax/blob/master/config/features.rb](https://github.com/samvera/hyrax/blob/master/config/features.rb) which defines keys and whether they are enabled by default.
+
+<ul class='warning'><li>If both options exist, whichever option is set from the Administrative Dashboard will take precedence.</li></ul>
+
+For a complete list of features and instructions on how to configure them, see the [Hyrax Feature-matrix](https://github.com/samvera/hyrax/wiki/Feature-matrix).

--- a/site_content/_software/hyrax/v2.0/devops/campus-auth-integrating.md
+++ b/site_content/_software/hyrax/v2.0/devops/campus-auth-integrating.md
@@ -1,0 +1,15 @@
+---
+title: "Integrating with Campus Authorization"
+permalink: campus-auth-integrating.html
+keywords: ["Integration", "Shibboleth", "Authorization"]
+tags: production
+summary: "An example of integrating with Shibboleth"
+toc: false
+---
+
+
+### Authenticate against Shibboleth
+
+There are probably many ways of doing this.
+
+Data Curation Experts has a repeatable way for accomplishing it, documented  [here](https://curationexperts.github.io/playbook/authentication/shibboleth.html).

--- a/site_content/_software/hyrax/v2.0/devops/service-stack.md
+++ b/site_content/_software/hyrax/v2.0/devops/service-stack.md
@@ -1,0 +1,19 @@
+---
+title: "The Services Stack"
+permalink: service-stack.html
+keywords: ["Solr", "Fedora", "Redis", "Services"]
+tags: production
+summary: "Services used in a production setting"
+---
+
+## Solr
+Solr is a search engine.  Samvera creates an index document (basically a Hash) for each PCDM object in Fedora and puts it into Solr.  This allows objects to be searched and discovered by a user.  ActiveFedora also uses Solr to run queries such as "Get me a list of objects that are Images"
+
+## Fedora Commons Repository (a.k.a. Fedora, a.k.a. FCRepo)
+Fedora is a data store that uses the LDP protocol to store linked data and binary files.
+
+## Rails
+Rails is a web application Framework for Ruby.
+
+## Redis
+Redis is a key-value store that we use to back our worker queues (using Resque or Sidekiq). Hyrax also uses Redis for user notifications.

--- a/site_content/_software/hyrax/v2.0/devops/troubleshooting-production.md
+++ b/site_content/_software/hyrax/v2.0/devops/troubleshooting-production.md
@@ -1,0 +1,71 @@
+---
+title: "Troubleshooting Production"
+permalink: troubleshooting-production.html
+keywords: ["Debugging", "Troubleshooting", "Production"]
+last_updated:
+tags: production
+summary: "Known issues regarding running in production"
+sidebar: home_sidebar
+---
+
+# Known gotchas
+
+## displaying default admin set raises exception
+Hyrax creates a default admin set that has a slash in its id ("admin_set/default").
+This means that unless your webserver is configured to allow encoded slashes,
+features that refer to the default admin set in the url will raise an exception.
+If you are using passenger on Ubuntu, you can fix this by adding this line to
+`/etc/apache2/conf-enabled/passenger.conf`:
+```
+  PassengerAllowEncodedSlashes on
+```
+The actual syntax might vary depending on your webserver configuration.
+
+## 'Failed to upgrade to WebSocket' ERROR for Hyrax notifications
+
+It's a known issue that Hyrax notifications don't work with Apache and Passenger.
+
+An alternative approach is to use puma and have Apache reverse proxy to the puma port. In this configuration, you may find that notifications still don't work, with `ERROR: Failed to upgrade to WebSocket` repeatedly appearing in the logs.
+
+The following configuration example has been successfully used as a fix for this issue in Centos7. Note, you will need mod_proxy and mod_proxy_wstunnel enabled.
+
+Please note that this configuration MAY also work with Passenger, but has not been tested.
+
+```
+<VirtualHost *:80>
+  ServerName localhost
+  DocumentRoot /var/lib/hyku/public
+  ProxyPreserveHost On
+
+  # Needed for RIIIF image server
+  AllowEncodedSlashes NoDecode
+
+  <Directory /var/lib/hyku/public>
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+  </Directory>
+
+  # Hyrax notifications require the following re-write configuration
+  #   otherwise notifications won't work and the log will contain lots of:
+  #   "ERROR: Failed to upgrade to WebSocket"
+  # Enable the rewrite engine
+  # Requires: sudo a2enmod proxy rewrite proxy_http proxy_wstunnel
+  # In the rules/conds, [NC] means case-insensitve, [P] means proxy
+  # See https://stackoverflow.com/questions/27526281/websockets-and-apache-proxy-how-to-configure-mod-proxy-wstunnel
+  RewriteEngine On
+
+  # socket.io 1.0+ starts all connections with a HTTP polling request
+  RewriteCond %{QUERY_STRING} notifications/endpoint       [NC]
+  RewriteRule /(.*)           http://localhost:3000/$1 [P]
+
+  # When socket.io wants to initiate a WebSocket connection, it sends an
+  # "upgrade: websocket" request that should be transferred to ws://
+  RewriteCond %{HTTP:Upgrade} websocket               [NC]
+  RewriteRule /(.*)           ws://localhost:3000/$1  [P]
+
+  ProxyPass / http://127.0.0.1:3000/
+  ProxyPassReverse / http://127.0.0.1:3000/
+</VirtualHost>
+
+```

--- a/site_content/_software/hyrax/v2.1/developer/access-controls.md
+++ b/site_content/_software/hyrax/v2.1/developer/access-controls.md
@@ -1,0 +1,62 @@
+---
+title: "Visibility and Access Controls"
+permalink: access-controls.html
+keywords: ["Visibility", "Access Controls", "Authorization"]
+last_updated:
+tags: [development_resources]
+summary: 'An overview of how Samvera applications authorize users to see content and perform actions'
+sidebar: home_sidebar
+---
+### Quickstart
+Samvera uses [cancancan](https://github.com/CanCanCommunity/cancancan#1-define-abilities) to do authorization of many actions.
+
+Cancancan generates `app/models/ability.rb` into your application and then hydra-head's generator and later Hyrax's generator each adds a couple of lines so that the class looks like this:
+
+```
+class Ability
+  include Hydra::Ability
+
+  include Hyrax::Ability
+  self.ability_logic += [:everyone_can_create_curation_concerns]
+
+  # Define any customized permissions here.
+  def custom_permissions
+    # Limits deleting objects to a the admin user
+    #
+    # if current_user.admin?
+    #   can [:destroy], ActiveFedora::Base
+    # end
+
+    # Limits creating new objects to a specific group
+    #
+    # if user_groups.include? 'special_group'
+    #   can [:create], ActiveFedora::Base
+    # end
+  end
+end
+```
+
+You don't need to make any changes to this class as the included behavior provides all that you need to get started.   However, if you are integrating an group system other than the default (See Hydra::RoleMapper), then you may want to change who has the admin role.
+
+You can do this by overriding the `admin?` method on the `Ability` class like this:
+
+```
+    def admin?
+      user_groups.include? 'librarians'
+    end
+```
+### Legacy
+
+In-depth tutorials and explanations of the structure
+
+- [Access Controls with Hydra 9](https://github.com/samvera/hydra-head/wiki/Access-Controls-with-Hydra)
+
+- [Access Controls with Hydra < 9](https://github.com/samvera/hydra-head/wiki/Access-Controls)
+
+### Potential for Refactoring
+
+Notes, links and ideas
+
+- [Oligarchical SaaS with CanCan](https://schwad.github.io/ruby/cancan/saas/2017/04/06/oligarchical-saas-with-cancan.html)
+
+- [Refacotoring Notes: Access Control Details, WIP](https://docs.google.com/document/d/1tWpV8b11WZ5qXP0ZHgFtatVuRg3YFUoMA7jPzU-QB34/edit?usp=sharing)

--- a/site_content/_software/hyrax/v2.1/developer/toggle-features.md
+++ b/site_content/_software/hyrax/v2.1/developer/toggle-features.md
@@ -1,0 +1,25 @@
+---
+title: "How to Enable and Disable Features"
+permalink: toggle-features.html
+keywords: [ "Configuration", "FlipFlop", "Feature Flipper" ]
+last_updated:
+tags: [development_resources]
+summary: 'A number of Hyrax features can be flipped on and off, either via the Administrative Dashboard or via a YAML configuration file'
+sidebar: home_sidebar
+toc: false
+---
+
+Some features in Hyrax can be flipped on and off from either the Administrative Dashboard, or via a YAML configuration file at `config/features.yml`. This .yml file doesn't ship with Hyrax but can easily be created.
+
+``` ruby
+assign_admin_set:
+  enabled: false
+proxy_deposit:
+  enabled: false
+```
+
+For a list of flipper features that can be configured in this way, see the [https://github.com/samvera/hyrax/blob/master/config/features.rb](https://github.com/samvera/hyrax/blob/master/config/features.rb) which defines keys and whether they are enabled by default.
+
+<ul class='warning'><li>If both options exist, whichever option is set from the Administrative Dashboard will take precedence.</li></ul>
+
+For a complete list of features and instructions on how to configure them, see the [Hyrax Feature-matrix](https://github.com/samvera/hyrax/wiki/Feature-matrix).

--- a/site_content/_software/hyrax/v2.1/devops/campus-auth-integrating.md
+++ b/site_content/_software/hyrax/v2.1/devops/campus-auth-integrating.md
@@ -1,0 +1,15 @@
+---
+title: "Integrating with Campus Authorization"
+permalink: campus-auth-integrating.html
+keywords: ["Integration", "Shibboleth", "Authorization"]
+tags: production
+summary: "An example of integrating with Shibboleth"
+toc: false
+---
+
+
+### Authenticate against Shibboleth
+
+There are probably many ways of doing this.
+
+Data Curation Experts has a repeatable way for accomplishing it, documented  [here](https://curationexperts.github.io/playbook/authentication/shibboleth.html).

--- a/site_content/_software/hyrax/v2.1/devops/service-stack.md
+++ b/site_content/_software/hyrax/v2.1/devops/service-stack.md
@@ -1,0 +1,19 @@
+---
+title: "The Services Stack"
+permalink: service-stack.html
+keywords: ["Solr", "Fedora", "Redis", "Services"]
+tags: production
+summary: "Services used in a production setting"
+---
+
+## Solr
+Solr is a search engine.  Samvera creates an index document (basically a Hash) for each PCDM object in Fedora and puts it into Solr.  This allows objects to be searched and discovered by a user.  ActiveFedora also uses Solr to run queries such as "Get me a list of objects that are Images"
+
+## Fedora Commons Repository (a.k.a. Fedora, a.k.a. FCRepo)
+Fedora is a data store that uses the LDP protocol to store linked data and binary files.
+
+## Rails
+Rails is a web application Framework for Ruby.
+
+## Redis
+Redis is a key-value store that we use to back our worker queues (using Resque or Sidekiq). Hyrax also uses Redis for user notifications.

--- a/site_content/_software/hyrax/v2.1/devops/troubleshooting-production.md
+++ b/site_content/_software/hyrax/v2.1/devops/troubleshooting-production.md
@@ -1,0 +1,71 @@
+---
+title: "Troubleshooting Production"
+permalink: troubleshooting-production.html
+keywords: ["Debugging", "Troubleshooting", "Production"]
+last_updated:
+tags: production
+summary: "Known issues regarding running in production"
+sidebar: home_sidebar
+---
+
+# Known gotchas
+
+## displaying default admin set raises exception
+Hyrax creates a default admin set that has a slash in its id ("admin_set/default").
+This means that unless your webserver is configured to allow encoded slashes,
+features that refer to the default admin set in the url will raise an exception.
+If you are using passenger on Ubuntu, you can fix this by adding this line to
+`/etc/apache2/conf-enabled/passenger.conf`:
+```
+  PassengerAllowEncodedSlashes on
+```
+The actual syntax might vary depending on your webserver configuration.
+
+## 'Failed to upgrade to WebSocket' ERROR for Hyrax notifications
+
+It's a known issue that Hyrax notifications don't work with Apache and Passenger.
+
+An alternative approach is to use puma and have Apache reverse proxy to the puma port. In this configuration, you may find that notifications still don't work, with `ERROR: Failed to upgrade to WebSocket` repeatedly appearing in the logs.
+
+The following configuration example has been successfully used as a fix for this issue in Centos7. Note, you will need mod_proxy and mod_proxy_wstunnel enabled.
+
+Please note that this configuration MAY also work with Passenger, but has not been tested.
+
+```
+<VirtualHost *:80>
+  ServerName localhost
+  DocumentRoot /var/lib/hyku/public
+  ProxyPreserveHost On
+
+  # Needed for RIIIF image server
+  AllowEncodedSlashes NoDecode
+
+  <Directory /var/lib/hyku/public>
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+  </Directory>
+
+  # Hyrax notifications require the following re-write configuration
+  #   otherwise notifications won't work and the log will contain lots of:
+  #   "ERROR: Failed to upgrade to WebSocket"
+  # Enable the rewrite engine
+  # Requires: sudo a2enmod proxy rewrite proxy_http proxy_wstunnel
+  # In the rules/conds, [NC] means case-insensitve, [P] means proxy
+  # See https://stackoverflow.com/questions/27526281/websockets-and-apache-proxy-how-to-configure-mod-proxy-wstunnel
+  RewriteEngine On
+
+  # socket.io 1.0+ starts all connections with a HTTP polling request
+  RewriteCond %{QUERY_STRING} notifications/endpoint       [NC]
+  RewriteRule /(.*)           http://localhost:3000/$1 [P]
+
+  # When socket.io wants to initiate a WebSocket connection, it sends an
+  # "upgrade: websocket" request that should be transferred to ws://
+  RewriteCond %{HTTP:Upgrade} websocket               [NC]
+  RewriteRule /(.*)           ws://localhost:3000/$1  [P]
+
+  ProxyPass / http://127.0.0.1:3000/
+  ProxyPassReverse / http://127.0.0.1:3000/
+</VirtualHost>
+
+```

--- a/site_content/_software/hyrax/v2.1/glossary.md
+++ b/site_content/_software/hyrax/v2.1/glossary.md
@@ -1,0 +1,109 @@
+---
+title: "Glossary of Terms"
+permalink: glossary-2.1.html
+keywords: ["Glossary", "Terms"]
+version:
+  id: hyrax_2.1-stable
+  label: 'Hyrax v2.1 (also applies to Hyrax v2.0.x)'
+sidebar: home_sidebar
+toc: false
+---
+
+## Administrative Set
+An Administrative Set is a top-level grouping of Works that is managed by a user with administrative privileges, such as reviewing deposited Works before they are made accessible. Unlike Collections, Administrative Sets are not discoverable by searching or browsing the catalog. They are intended to provide repository administrators the ability to apply a workflow, define behaviors, and apply policies on a set of works. Only repository administrators can create an administrative set, but they can designate any user to have management or edit access to an administrative set. All works must belong to one, and only, one Admin Set. Example: Electronic Dissertations and Theses. ([more information...](admin-sets-as-collections-faq.html))
+
+## Child Work
+The lower-level work in a work-to-work relationship. Children can have one or more parent works. The same work can be a parent and a child.
+
+## Collection
+A thematic grouping of works or collections. Any user in the system can create a Collection. Collections can be visible publicly or kept private. Collections can have a dedicated thumbnail and be shared among repository users with defined access levels: view/download or edit. Only users with access to a collection can add Works to it. Example: Professor creates a collection of Works related to her funded research project. ([more information...](collection-overview.html))
+
+## Collection Type
+Collection Types provide a means for configuring behavior of collections within a site.  The functionality that can be switched on/off are [nesting](collection-nesting-faq.html), [sharing](collection-sharing.html), [discovery](collection-discovery-faq.html), multiple-membership, and branding.  Once collections of a type have been created, these configurations can no longer be changed.  A site may want to create several collection types (e.g. exhibits and user collections).  ([more information...](collection-types.html))
+
+## Fileset
+The container representing a single file uploaded to the repository. It is a set that holds the original uploaded file and any generated derivative files (e.g. thumbnails, full text, etc.).
+
+## Groups
+Groups of users, controlled by administrators.  Groups can be assigned as Participants for Collection Types and Admin Sets and given Sharing roles for Collections and Works.  
+
+See also [Setting groups vs. users as participants](collection-sharing.html#setting-groups-vs-users-as-participants).
+
+## Mediated deposit
+The group of steps necessary for reviewing a deposited work, culminating in approval before publishing it for public viewing. Commonly used in the context of collecting Electronic Theses and Dissertations or staff-facing metadata workflows for digital collections.
+
+## Participants
+Participants for Administrative Sets allow the repository manager to define what individual users or groups of users can do with or to items in an Admin Set, such as deposit, approve, edit, or withdraw.
+
+Participants for Collection Types allow the repository manager to define which individual users or groups of users can have roles related to collections of a type.  A manager is given full edit access to collections of this type.  A creator is allowed to create new collections of this type.  ([more information...](collection-type-participants.html))
+
+See also [Sharing](#sharing) which describes roles for Collections and Works.<br>
+See also [Setting groups vs. users as participants](collection-sharing.html#setting-groups-vs-users-as-participants).
+
+**Permission Templates**
+A template that defines the Visibility, Release, Workflow, and Participants for an Admin Set or Collection.  The template is applied to works when the work is created.  The template is created through the UI when an Admin Set or Collection is created or edited.  Permission Templates are applied to works when the item is created.  Changes to the template are not applied to existing works and will only effect new works created after the change.
+
+**Collection Type Templates**
+A template that defines the Participants for Collection based on it's Collection Type.  The template is applied to collections when the collection is created.  The template is created through the UI when a Collection Type is created or edited.  Collection Type Templates are applied to collections when the item is created.  Changes to the template are not applied to existing collections and will only effect new collections created after the change.
+
+## Mediated Deposit Workflow
+The group of steps necessary for reviewing an ingested item and its metadata, culminating in approval before publishing it for public viewing.  ([more information...](https://github.com/samvera/sufia/wiki/Mediated-Deposit-Workflow))
+
+## Parent Work
+The higher-level work in a work-to-work relationship where there is at least one child work relationship established. Parents can have one or more child works. The same work can be a parent and a child.
+
+## Proxy
+A user who can deposit works on behalf of another user. Example. Research Assistant deposits articles written by a Professor.
+
+## Resource Type
+A classification for content that is assigned to the Work by the depositor. Resource Types are discoverable via facet by default. Examples include: Article, Dataset, Image.
+
+## Roles
+
+**System Roles**
+
+Repository Administrator is the only system-wide role that exists out of the box. Repository Administrators:
+- Can see, edit, delete all works, collections, admin sets regardless of access controls and workflows on the objects.
+- Only Repository Administrators can
+  - create Administrative Sets
+  - manage user roles system-wide
+  - access the repository configuration settings
+
+Registered User is any user that is logged into the repository.
+Public User is anyone visiting the public contents of the repository.
+
+**Repository Object Roles** (e.g. Collection Type, Collection, Administrative Set, and Work Roles)
+
+In addition to system roles, there are Collection Type based, Collection based, Admin Set based, and Work based roles, but these are limited to specific items in the repository and not across all content in the system. These include:
+- Manager and Creators of a Collection Type ([Participants](#participants))
+- Viewers, Depositors, Managers of an Administrative Set ([Participants](#participants))
+- Viewers, Depositors, Managers of a Collection ([Sharing](#sharing))
+- Work Editors, Viewers ([Sharing](#sharing))
+
+**Workflow Roles**
+
+Roles that a user or group of users can perform in a workflow.  These define the functions a person performs during a step in a workflow.
+- creating work
+- approving work
+
+See also [Medidated Deposit Workflow](#mediated-deposit-workflow)
+
+## Sharing
+Sharing roles for Collections allow editors of the collection to share responsibility of the collection with individual users or groups of users.  Managers are given full edit access to the collection.  Depositors can add resources to the collection.  And viewers can see the collection even when it is private.  These roles can optionally be applied to works created in the collection.  ([more information...](collection-sharing.html))
+
+Works can be shared giving individual users or groups of users edit access or read access.  Edit access give the users full editing access to the work.  Read access allows users to view the work even when it is private.
+
+See also [Participants](#participants) which describes roles for Collections and Works.<br>
+See also [Setting groups vs. users as participants](collection-sharing.html#setting-groups-vs-users-as-participants).
+
+## Work
+The basic content item in the repository. Works bring together file(s) and associated metadata and presents them as one intellectual object. Example: A single dissertation (PDF and descriptive information) or a dataset containing multiple files (spreadsheets, images, text files and descriptive information).
+
+## Workflows
+Workflows can be used in conjunction with and Admin Set to dictate the process by which a work is submitted, reviewed, and published. For example, Senior Honors Theses need to be reviewed and approved by advisors before becoming available to the general public in the repository.  Two workflows come predefined.  The first immediately saves the work as complete.  The other is a [Mediated Deposit](#mediated-deposit-workflow) workflow requiring review.
+
+## Work Ownership
+Works are usually owned by the user who makes the deposit, unless that user is a Proxy for another user. Work ownership can be transferred between current users of the system.
+
+## Work Type
+A classification tool for the submission of distinct types of works. Custom work types can be generated to allow different descriptive metadata to be collected as appropriate for the classification. Work Types are discoverable via facet by default. Examples include: Publication, Dataset, Image.  Work types are also known as Curation Concerns.


### PR DESCRIPTION
Adds the remaining markdown files from (current) samvera.github.io.

Some were non-versioned software documentations pages that were copied to all versions of Hyrax.

These should probably be reviewed to ensure they are accurate for the given version.