### PR TITLE
Upgrades to Jekyll 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'rake'
+gem 'jekyll', '~> 4.0'
 
 group :jekyll_plugins do
-  gem 'jekyll-menus'
   gem 'jekyll-ship', github: 'afred/jekyll-ship'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/afred/jekyll-ship.git
-  revision: 7eeb440beb593f956efa12a289fa59bcde6b6c87
+  revision: d7dc4ca13c10d5853106bc5bcf6b3804aa94c658
   specs:
-    jekyll-ship (0.2.0)
-      activesupport (~> 5)
-      aws-sdk-s3 (~> 1)
-      jekyll (~> 3.8)
+    jekyll-ship (0.2.1)
+      activesupport (~> 5.2)
+      aws-sdk-s3 (~> 1.46)
+      jekyll (>= 3.8, < 5)
 
 GEM
   remote: https://rubygems.org/
@@ -18,8 +18,8 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.200.0)
-    aws-sdk-core (3.62.0)
+    aws-partitions (1.203.0)
+    aws-sdk-core (3.64.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -44,30 +44,32 @@ GEM
     ffi (1.11.1)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
-    i18n (0.9.5)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.5)
+    jekyll (4.0.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (~> 0.7)
-      jekyll-sass-converter (~> 1.0)
+      i18n (>= 0.9.5, < 2)
+      jekyll-sass-converter (~> 2.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
+      rouge (~> 3.0)
       safe_yaml (~> 1.0)
-    jekyll-menus (0.6.0)
-      jekyll (~> 3.1)
-    jekyll-sass-converter (1.5.2)
-      sass (~> 3.4)
+      terminal-table (~> 1.8)
+    jekyll-sass-converter (2.0.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     jmespath (1.4.0)
-    kramdown (1.17.0)
-    liquid (4.0.0)
+    kramdown (2.1.0)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -84,30 +86,28 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (3.1.1)
-    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rouge (2.2.1)
+    rouge (3.9.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    sassc (2.1.0)
+      ffi (~> 1.9)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll-menus
+  jekyll (~> 4.0)
   jekyll-ship!
   pry-byebug
-  rake
 
 BUNDLED WITH
    2.0.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,0 @@
-# Add 'lib' directory to load path so rake tasks can require libs from there.
-$LOAD_PATH << File.expand_path('lib', File.dirname(__FILE__))
-
-# Load all .rake files under /tasks directory.
-Dir.glob('tasks/**/*.rake').each { |file| load file }

--- a/_config.yml
+++ b/_config.yml
@@ -1,18 +1,3 @@
-exclude: [
-  "Gemfile",
-  "Gemfile.lock",
-  "Rakefile",
-  "lib",
-  "tasks",
-  "spec",
-  "node_modules",
-  "vendor/bundle/",
-  "vendor/cache/",
-  "vendor/gems/",
-  "vendor/ruby/",
-  "*.rb"
-]
-
 # Default frontmatter
 defaults:
   -
@@ -44,14 +29,6 @@ collections:
     output: true
 
 collections_dir: site_content
-
-publish:
-  git_remote: git@github.com:samvera-labs/samvera_docs.git
-  git_branch: gh-pages
-
-plugins:
-  - jekyll-menus
-  # - jekyll-ship
 
 sass:
   sass_dir: _sass


### PR DESCRIPTION
Also,
* Removes jekyll-memus from registered plugins because we arn't using it atm.
* Removes unnecessary `exclude` config in _config.yml.
* Removes unused Rakefile and tasks directory.
* Removes unused `publish` config option. Use options for jekyll-ship instead.